### PR TITLE
Fix C++ standard lib include fails on clang+Linux

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -17,7 +17,7 @@ config()
     rm -rf ${BUILDDIR}
     mkdir ${BUILDDIR}
     cd ${BUILDDIR}
-    cmake .. -DCMAKE_INSTALL_PREFIX=${PREFIX}
+    cmake .. -DWITH_LIBCXX=off -DCMAKE_INSTALL_PREFIX=${PREFIX}
 }
 
 build()


### PR DESCRIPTION
Provide '-DWITH_LIBCXX=off' option to cmake invocation.  This
suppresses addition of the '-stdlib=c++' compiler flag option
in the resulting Makefiles, for just the clang+Linux platform.